### PR TITLE
feat: millisecond precision elapsed time tracking

### DIFF
--- a/unicon_runner/cli.py
+++ b/unicon_runner/cli.py
@@ -177,14 +177,21 @@ def test(
     async def _run_job(program: Program) -> ProgramResult:
         # Since this is a test, we don't want to clean up the working directory
         # This is so that we can easily inspect the files written and replay the execution
-        return await executor.run(program, job.context, cleanup=False)
+        return await executor.run(program, job.context, cleanup=False, track_elapsed_time=True)
 
     for i, program in enumerate(job.programs):
         prog_result = asyncio.run(_run_job(program))
+        assert prog_result.elapsed_time_ns is not None
 
         tbl = Table(title=f"Program Result #{i + 1}", highlight=True)
         tbl.add_column("status", style="magenta")
         tbl.add_column("stdout")
         tbl.add_column("stderr", style="red")
-        tbl.add_row(prog_result.status, prog_result.stdout, prog_result.stderr)
+        tbl.add_column("Elapsed Time (ms)", style="green")
+        tbl.add_row(
+            prog_result.status,
+            prog_result.stdout,
+            prog_result.stderr,
+            f"{prog_result.elapsed_time_ns / 1e6:.4f}ms",
+        )
         _console.print(tbl)

--- a/unicon_runner/constants.py
+++ b/unicon_runner/constants.py
@@ -13,7 +13,7 @@ def _get_env_var(name: str, default: str | None = None, required: bool = True):
     return value
 
 
-AMQP_URL: Final[str] = _get_env_var("AMQP_URL")
+AMQP_URL: Final[str] = _get_env_var("AMQP_URL", required=False)
 AMQP_EXCHANGE_NAME: Final[str] = _get_env_var("AMQP_EXCHANGE_NAME", "unicon")
 AMQP_TASK_QUEUE_NAME: Final[str] = _get_env_var("AMQP_TASK_QUEUE_NAME", "unicon.tasks")
 AMQP_RESULT_QUEUE_NAME: Final[str] = _get_env_var("AMQP_RESULT_QUEUE_NAME", "unicon.results")

--- a/unicon_runner/executor/base.py
+++ b/unicon_runner/executor/base.py
@@ -189,7 +189,11 @@ class Executor(ABC):
                     env={**os.environ, **env_vars},
                 )
             )
-            perf = collect_perf_results(workspace) if track_elapsed_time else None
+
+            if perf := (collect_perf_results(workspace) if track_elapsed_time else None):
+                logger.info(f"[Setup] Create venv: {perf.create_venv_ns / 1e6:.4f}ms")
+                logger.info(f"[Setup] Install deps: {perf.install_deps_ns / 1e6:.4f}ms")
+                logger.info(f"[Program] Elapsed time: {perf.program_ns / 1e6:.4f}ms")
 
         match result.exit_code:
             case 137:

--- a/unicon_runner/executor/base.py
+++ b/unicon_runner/executor/base.py
@@ -211,6 +211,6 @@ class Executor(ABC):
                 "status": status.value,
                 "stdout": result.stdout,
                 "stderr": result.stderr,
-                "elpased_time_ns": perf.program_ns if perf else None,
+                "elapsed_time_ns": perf.program_ns if perf else None,
             }
         )

--- a/unicon_runner/executor/podman.py
+++ b/unicon_runner/executor/podman.py
@@ -8,7 +8,7 @@ from unicon_runner.models import ComputeContext, Program
 class PodmanExecutor(Executor):
     """Uses podman + Dockerfile in template to execute code"""
 
-    def get_filesystem_mapping(self, program: Program, _: ComputeContext) -> FileSystemMapping:
+    def get_filesystem_mapping(self, program: Program, *_unused) -> FileSystemMapping:
         return [(Path(file.name), file.content, False) for file in program.files]
 
     def _cmd(self, cwd: Path, program: Program, context: ComputeContext) -> ExecutorCmd:

--- a/unicon_runner/executor/templates/run_unsafe.sh.jinja
+++ b/unicon_runner/executor/templates/run_unsafe.sh.jinja
@@ -3,9 +3,31 @@
 # Change directory to the working directory
 cd "$(dirname "$0")"
 
-# Install required Python interpreter and dependencies
-uv -q venv --python {{ python_version }}
-uv -q --no-cache add -r requirements.txt
+cmd_create_venv="uv -q venv --python {{ python_version }}"
+cmd_install_deps="uv -q --no-cache add -r requirements.txt"
+cmd_run="timeout {{ time_limit_secs }} uv -q run {{ entry_point }}"
+
+{% if track_elapsed_time %}
+measure_elapsed_time() {
+    local command="$1"
+    local output_file="$2"
+
+    local start_time_ns=$(date +%s%N)
+    eval "$command"
+    local end_time_ns=$(date +%s%N)
+
+    local execution_time_ns=$((end_time_ns - start_time_ns))
+    echo "$execution_time_ns" > "$output_file"
+}
+{% endif %}
+
+{% if track_elapsed_time %}
+measure_elapsed_time "$cmd_create_venv" {{ create_venv_time_file }}
+measure_elapsed_time "$cmd_install_deps" {{ install_deps_time_file }}
+{% else %}
+$cmd_create_venv
+$cmd_install_deps
+{% endif %}
 
 # NOTE: Memory limit is set in kilobytes
 # Reference: https://ss64.com/bash/ulimit.html
@@ -13,7 +35,11 @@ ulimit -v {{ memory_limit_kb }}
 # NOTE: Exit code is preserved if process is does not exceed time limit
 # NOTE: Time limit is set in seconds
 # Reference: https://www.man7.org/linux/man-pages/man1/timeout.1.html
-timeout {{ time_limit_secs }} uv -q run {{ entry_point }}
+{% if track_elapsed_time %}
+measure_elapsed_time "$cmd_run" {{ run_time_file }}
+{% else %}
+$cmd_run
+{% endif %}
 
 {% block append %}
 {% endblock append %}

--- a/unicon_runner/executor/templates/run_unsafe.sh.jinja
+++ b/unicon_runner/executor/templates/run_unsafe.sh.jinja
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 
 cmd_create_venv="uv -q venv --python {{ python_version }}"
 cmd_install_deps="uv -q --no-cache add -r requirements.txt"
-cmd_run="timeout {{ time_limit_secs }} uv -q run {{ entry_point }}"
+cmd_run_program="timeout {{ time_limit_secs }} uv -q run {{ entry_point }}"
 
 {% if track_elapsed_time %}
 measure_elapsed_time() {
@@ -36,10 +36,7 @@ ulimit -v {{ memory_limit_kb }}
 # NOTE: Time limit is set in seconds
 # Reference: https://www.man7.org/linux/man-pages/man1/timeout.1.html
 {% if track_elapsed_time %}
-measure_elapsed_time "$cmd_run" {{ run_time_file }}
+measure_elapsed_time "$cmd_run_program" {{ program_time_file }}
 {% else %}
-$cmd_run
+$cmd_run_program
 {% endif %}
-
-{% block append %}
-{% endblock append %}

--- a/unicon_runner/executor/templates/slurm.sh.jinja
+++ b/unicon_runner/executor/templates/slurm.sh.jinja
@@ -11,3 +11,13 @@ cp -r {{ staging_dir }}/* {{ exec_dir }}
 
 # Run the job script
 {{ run_script }}
+
+# Preserve exit code of job script
+job_script_exit_code=$?
+
+# Copy all files from the execution directory to the NFS staging directory
+{% for file in files_to_preserve %}
+cp {{ exec_dir }}/{{ file }} {{ staging_dir }}/
+{% endfor %}
+
+exit $job_script_exit_code

--- a/unicon_runner/executor/unsafe.py
+++ b/unicon_runner/executor/unsafe.py
@@ -14,7 +14,10 @@ class UnsafeExecutor(Executor):
     ENTRYPOINT: Path = Path("run.sh")
 
     def get_filesystem_mapping(
-        self, program: Program, context: ComputeContext
+        self,
+        program: Program,
+        context: ComputeContext,
+        elapsed_time_tracking_files: dict[str, str] | None = None,
     ) -> FileSystemMapping:
         package_dir = Path("src")
 
@@ -35,6 +38,8 @@ class UnsafeExecutor(Executor):
             memory_limit_kb=context.memory_limit_mb * 1024,
             time_limit_secs=context.time_limit_secs,
             entry_point=str(package_dir / program.entrypoint),
+            track_elapsed_time=elapsed_time_tracking_files is not None,
+            **(elapsed_time_tracking_files or {}),
         )
 
         return [

--- a/unicon_runner/models.py
+++ b/unicon_runner/models.py
@@ -65,11 +65,21 @@ class ProgramResult(BaseModel):
     stderr: str | None
     status: Status | None
 
+    elapsed_time_ns: int | None
+
+
+class ExecutorPerf(BaseModel):
+    create_venv_ns: int
+    install_deps_ns: int
+    program_ns: int
+
 
 class ExecutorResult(BaseModel):
     exit_code: int
     stdout: str
     stderr: str
+
+    perf: ExecutorPerf | None = None
 
 
 class Job(BaseModel):

--- a/unicon_runner/models.py
+++ b/unicon_runner/models.py
@@ -65,7 +65,7 @@ class ProgramResult(BaseModel):
     stderr: str | None
     status: Status | None
 
-    elapsed_time_ns: int | None
+    elapsed_time_ns: int | None = None
 
 
 class ExecutorPerf(BaseModel):


### PR DESCRIPTION
This PR implements wall clock time tracking for setup and program execution processes. The proposed implementation in the PR provides nano-second precision at the cost of **only** tracking elapsed (wall clock) time and forgoing CPU time (also `usr` and `sys`). Elapsed time seems to be metrics that most tasks and CP competition focuses on, hence I felt the trade off was justified.

The most straight forward way to time a process is via the `time` command. `time` could either be the builtin command provided by shells (e.g. `bash`, `fish`) or the GNU `time` binary. The precision provided by these implementations differ, where GNU `time` only provides **10ms** precision while `bash` offers **millisecond** (1ms) precision. Both commands also provide metrics such as CPU time and many more (https://man7.org/linux/man-pages/man1/time.1.html). Since millisecond precision is the requirement, GNU `time` is out of the picture. _From now onwards, `time` refers to the `bash`'s builtin command._

Although `time` satisfies our precision requirement, the biggest challenge seems to be redirecting the output away from `stderr` since it will collide with program `stderr`. In theory, we could do some shell magic to strip it away and pipe it into another file that we control, however this complicates our execution harness and might change how program `stdout` and `stderr` are piped and read by the post execution logic of our executors.

As such, with all things considered, using the `date` command (https://man7.org/linux/man-pages/man1/date.1.html) seems to be the best solution considering requirements and overhead. It offers nanosecond precisions and by checking the epoch time right before and after the program runs we get the elapsed wall time. Furthermore, we do not have to deal with `stdout` and `stderr` since we get to save these values as variables in our execution harness `bash` script.

Example:

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/ee28c6e2-eafe-4b3f-9afc-5c07e4806f30" />


