### PR TITLE
fix: podman executor strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,8 @@ DEFAULT_EXEC_PY_VERSION="3.11.9"
 # Default options and flags to pass to the executor if a `slurm` execution is required
 # This is useful for specifying default resources based on where the executor is running e.g. always run on a particular partition
 DEFAULT_SLURM_OPTS=""
+
+# Uncomment these lines if you are running unsafe/podman executors locally on a Mac.
+# This is not recommended for production use.
+# SLURM_DISABLED="1"
+# ULIMIT_DISABLED="1"

--- a/unicon_runner/constants.py
+++ b/unicon_runner/constants.py
@@ -26,3 +26,7 @@ CONTY_PATH: Final[str] = _get_env_var("CONTY_PATH", "conty.sh")
 CONTY_DOWNLOAD_URL: Final[str] = _get_env_var(
     "CONTY_DOWNLOAD_URL", "https://github.com/uniconhq/conty/releases/latest/download/conty.sh"
 )
+
+# The only reason you set this to 1 is probably because you are running this locally on a Mac.
+SLURM_DISABLED = _get_env_var("SLURM_DISABLED", "0") == "1"
+ULIMIT_DISABLED = _get_env_var("ULIMIT_DISABLED", "0") == "1"

--- a/unicon_runner/executor/base.py
+++ b/unicon_runner/executor/base.py
@@ -13,7 +13,7 @@ from typing import Final
 import psutil
 from jinja2 import Environment, PackageLoader, select_autoescape
 
-from unicon_runner.constants import DEFAULT_SLURM_OPTS
+from unicon_runner.constants import DEFAULT_SLURM_OPTS, SLURM_DISABLED
 from unicon_runner.models import (
     ComputeContext,
     ExecutorPerf,
@@ -116,7 +116,7 @@ class Executor(ABC):
     def is_compatible(self, context: ComputeContext) -> tuple[bool, str]:
         # NOTE: We assume that as long as the working directory is on **any** NFS,
         # all nodes in the cluster will have access to it
-        if context.slurm and not is_mounted_on_nfs(self._root_dir):
+        if not SLURM_DISABLED and context.slurm and not is_mounted_on_nfs(self._root_dir):
             return False, "Cannot run slurm job as working directory is not on NFS"
         return True, ""
 
@@ -148,7 +148,7 @@ class Executor(ABC):
             cmd: list[str]
             env_vars: dict[str, str]
 
-            if context.slurm:
+            if not SLURM_DISABLED and context.slurm:
                 # NOTE: For `slurm` execution, the working directory needs to be in NFS
                 # There will be 2 working directories:
                 # 1. NFS working directory (where the setup is done)

--- a/unicon_runner/executor/templates/run_unsafe.sh.jinja
+++ b/unicon_runner/executor/templates/run_unsafe.sh.jinja
@@ -33,7 +33,12 @@ eval "$cmd_install_deps"
 
 # NOTE: Memory limit is set in kilobytes
 # Reference: https://ss64.com/bash/ulimit.html
+{% if disable_ulimit %}
+run_cmd="timeout {{ time_limit_secs }} bash -c \"$cmd_run_program\""
+{% else %}
 run_cmd="timeout {{ time_limit_secs }} bash -c \"ulimit -v {{ memory_limit_kb }} && $cmd_run_program\""
+{% endif %}
+
 
 # NOTE: Exit code is preserved if process does not exceed time limit
 # NOTE: Time limit is set in seconds

--- a/unicon_runner/executor/unsafe.py
+++ b/unicon_runner/executor/unsafe.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from jinja2 import Template
 
-from unicon_runner.constants import DEFAULT_EXEC_PY_VERSION
+from unicon_runner.constants import DEFAULT_EXEC_PY_VERSION, SLURM_DISABLED, ULIMIT_DISABLED
 from unicon_runner.executor.base import JINJA_ENV, Executor, ExecutorCmd, FileSystemMapping
 from unicon_runner.models import ComputeContext, Program
 
@@ -27,7 +27,7 @@ class UnsafeExecutor(Executor):
         )
 
         python_version: str = DEFAULT_EXEC_PY_VERSION
-        if context.slurm and context.slurm_use_system_py:
+        if not SLURM_DISABLED and context.slurm and context.slurm_use_system_py:
             # NOTE: We need to use the system python interpreter for slurm jobs
             # This is because of filesystem restrictions in the slurm environment (more details in the docs)
             python_version = "/usr/bin/python"
@@ -40,6 +40,7 @@ class UnsafeExecutor(Executor):
             time_limit_secs=context.time_limit_secs,
             entry_point=str(package_dir / program.entrypoint),
             track_elapsed_time=elapsed_time_tracking_files is not None,
+            disable_ulimit=ULIMIT_DISABLED,
             **(elapsed_time_tracking_files or {}),
         )
 
@@ -51,6 +52,6 @@ class UnsafeExecutor(Executor):
             (self.ENTRYPOINT, run_script, True),
         ]
 
-    def _cmd(self, cwd: Path, *_unused) -> ExecutorCmd:
+    def _cmd(self, cwd: Path, _: Program, __: ComputeContext) -> ExecutorCmd:
         # NOTE: We need to unset VIRTUAL_ENV to prevent uv from using the wrong base python interpreter
         return [str(cwd / self.ENTRYPOINT)], {"VIRTUAL_ENV": "''"}


### PR DESCRIPTION
- make podman run again
- add environment variables to disable slurm/ulimit for mac users
  - this is for convenience during development and should never be enabled on our runners.